### PR TITLE
fix: Removing victory region from location add loop

### DIFF
--- a/worlds/dredge/__init__.py
+++ b/worlds/dredge/__init__.py
@@ -116,13 +116,13 @@ class DredgeWorld(World):
             location = DredgeLocation(self.player, location_name, location_id, region)
             region.locations.append(location)
 
-            victory_region = self.get_region("Insanity")
-            victory_location = DredgeLocation(self.player, "The Collector", None, victory_region)
-            victory_location.place_locked_item(DredgeItem("Victory",
-                                                          ItemClassification.progression,
-                                                          None, self.player))
-            self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player)
-            victory_region.locations.append(victory_location)
+        victory_region = self.get_region("Insanity")
+        victory_location = DredgeLocation(self.player, "The Collector", None, victory_region)
+        victory_location.place_locked_item(DredgeItem("Victory",
+                                                      ItemClassification.progression,
+                                                      None, self.player))
+        self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player)
+        victory_region.locations.append(victory_location)
 
     def set_rules(self) -> None:
         set_region_rules(self)


### PR DESCRIPTION
## What is this fixing or adding?
During game generation there was a repeat error where the victory region was showing up as a duplicate due to what appears to be a for-loop issue where the victory location was being set every time a new location was added to the game. 

This change moves the `victory_region.locations.append(victory_location)` call to only be made once in the `create_regions` function during world initialization.

```
Generation failed with error:            ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Administrator\Documents\Archipelago\Main.py", line 97, in main
    AutoWorld.call_all(multiworld, "create_regions")
  File "C:\Users\Administrator\Documents\Archipelago\worlds\AutoWorld.py", line 196, in call_all
    call_single(multiworld, method_name, player, args)
  File "C:\Users\Administrator\Documents\Archipelago\worlds\AutoWorld.py", line 186, in call_single
    raise e
  File "C:\Users\Administrator\Documents\Archipelago\worlds\AutoWorld.py", line 179, in call_single
    ret = _timed_call(method,args, multiworld=multiworld, player=player)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Administrator\Documents\Archipelago\worlds\AutoWorld.py", line 165, in _timed_call
    ret = method(*args)
          ^^^^^^^^^^^^^
  File "C:\Users\Administrator\Documents\Archipelago\custom_worlds\dredge.apworld\dredge__init__.py", line 125, in create_regions
  File "<frozen _collections_abc>", line 1078, in append
  File "C:\Users\Administrator\Documents\Archipelago\BaseClasses.py", line 1178, in insert
    assert value.name not in self.region_manager.location_cache[value.player], \
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: The Collector already exists in the location cache.
Exception in <bound method DredgeWorld.create_regions of <worlds.dredge.DredgeWorld object at 0x000001B914578950>>
```

## How was this tested?
Manual generation/server launch