### PR TITLE
Don't create location groups based on location names

### DIFF
--- a/worlds/dredge/locations.py
+++ b/worlds/dredge/locations.py
@@ -92,8 +92,9 @@ def get_player_location_table(options: DREDGEOptions) -> Dict[str, bool]:
 
 LOCATION_NAME_GROUPS: Dict[str, Set[str]] = {}
 for loc_name, loc_data in location_table.items():
-    loc_group_name = loc_name.split(" - ", 1)[0]
-    LOCATION_NAME_GROUPS.setdefault(loc_group_name, set()).add(loc_name)
+    loc_name_components = loc_name.split(" - ", 1)
+    if len(loc_name_components) > 1:
+        LOCATION_NAME_GROUPS.setdefault(loc_name_components[0], set()).add(loc_name)
     if loc_data.location_group:
         LOCATION_NAME_GROUPS.setdefault(loc_data.location_group, set()).add(loc_name)
 

--- a/worlds/dredge/locations.py
+++ b/worlds/dredge/locations.py
@@ -92,9 +92,6 @@ def get_player_location_table(options: DREDGEOptions) -> Dict[str, bool]:
 
 LOCATION_NAME_GROUPS: Dict[str, Set[str]] = {}
 for loc_name, loc_data in location_table.items():
-    loc_name_components = loc_name.split(" - ", 1)
-    if len(loc_name_components) > 1:
-        LOCATION_NAME_GROUPS.setdefault(loc_name_components[0], set()).add(loc_name)
     if loc_data.location_group:
         LOCATION_NAME_GROUPS.setdefault(loc_data.location_group, set()).add(loc_name)
 


### PR DESCRIPTION
## What is this fixing or adding?
This change prevents the creation of location groups that have the same name as locations, which fixes a [unit test](https://github.com/alextric234/ArchipelagoDredge/blob/5eb1777ce14e6cacc3f76121d548ff770bc8dc33/test/general/test_locations.py#L69-L77) failure

## How was this tested?
I ran the AP unit tests, they passed

## If this makes graphical changes, please attach screenshots.
N/A